### PR TITLE
Restore remote focus when controls are toggled

### DIFF
--- a/com.sk.app.lgtv-vpn/js/index.js
+++ b/com.sk.app.lgtv-vpn/js/index.js
@@ -33,10 +33,20 @@ function setButtonLabel(state) {
   const btn = document.getElementById('cbtn');
   btn.innerText = state === "CONNECTED" ? "Stop" : "Connect";
 }
-function setButtonDisabled(dis) { document.getElementById('cbtn').disabled = dis; 
-  SpatialNavigation.makeFocusable();}
-function setDropdownDisabled(dis) { document.getElementById('configDropdown').disabled = dis; 
-  SpatialNavigation.makeFocusable();}
+function focusFirstEnabledItem() {
+  const enabledItem = Array.from(document.getElementsByClassName('item'))
+    .find(el => !el.disabled);
+
+  if (enabledItem && document.activeElement?.disabled) {
+    enabledItem.focus();
+  }
+}
+function setButtonDisabled(dis) { document.getElementById('cbtn').disabled = dis;
+  SpatialNavigation.makeFocusable();
+  focusFirstEnabledItem();}
+function setDropdownDisabled(dis) { document.getElementById('configDropdown').disabled = dis;
+  SpatialNavigation.makeFocusable();
+  focusFirstEnabledItem();}
 
 function updateStateLabel(text, cls = null) {
   const s = document.getElementById('state');


### PR DESCRIPTION
## Summary
- add a helper to restore focus to the first enabled control when UI elements are toggled
- refresh spatial navigation and focus after enabling or disabling the connect button or profile dropdown

## Testing
- not run (not available)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692da9fc58348329bbdb41f185e24278)